### PR TITLE
fix(ledger): honour reducers when computing state_after

### DIFF
--- a/src/argus/ledger.py
+++ b/src/argus/ledger.py
@@ -50,25 +50,23 @@ def build_ledger(
     Retried and skipped events are kept: later rows are the evidence that a
     downstream node was the victim rather than the origin.
     """
-    # ponytail: plain dict overlay for the running state — last write wins.
-    # Measured limitation: for a field declared `Annotated[list, operator.add]`,
-    # a node returning `{"docs": []}` leaves `state_after["docs"] == []` here
-    # while LangGraph really keeps the accumulated list. Grading is unaffected
-    # (session.py merges with the real reducers, and `_lacks` in contextual.py
-    # only treats None as missing), but the notebook's running state is wrong
-    # for reduced fields.
-    # Not fixed live-only on purpose: reducers are callables and do not survive
-    # the run file, so a live-only fix would make the reloaded notebook differ
-    # from the live one and break re-score. Fixing it properly means persisting
-    # reducer identity, or rebuilding state_after from each successor's recorded
-    # input_state (needs the edge map for fan-out).
+    # Running state is rebuilt from each successor's recorded input_state when
+    # one exists. That value is the framework's post-reducer merge, so reduced
+    # fields (e.g. Annotated[list, operator.add]) stay correct without storing
+    # reducer callables — live and reloaded notebooks stay identical.
+    # The last step has no successor, so it still uses a last-write-wins overlay.
     running: dict[str, Any] = dict(initial_state or {})
     rows: list[LedgerRow] = []
+    events = list(steps)
 
-    for event in steps:
+    for i, event in enumerate(events):
         update = event.output_dict
         if update:
             running = {**running, **update}
+        if i + 1 < len(events):
+            nxt = getattr(events[i + 1], "input_state", None)
+            if nxt:
+                running = dict(nxt)
         rows.append(
             LedgerRow(
                 step_index=event.step_index,

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -5,7 +5,8 @@ Invoke once, load the saved run, build the ledger from *that*, and grade it.
 
 from __future__ import annotations
 
-from typing import TypedDict
+import operator
+from typing import Annotated, TypedDict
 
 import pytest
 
@@ -93,3 +94,46 @@ def test_ledger_from_live_steps_matches_the_reloaded_one():
     assert [(r.node, r.update, r.state_after, r.tools) for r in live] == [
         (r.node, r.update, r.state_after, r.tools) for r in reloaded
     ]
+
+
+class _Reduced(TypedDict, total=False):
+    docs: Annotated[list, operator.add]
+
+
+def _reduced_app():
+    def seed(state: _Reduced) -> dict:
+        return {"docs": ["seed"]}
+
+    def empty(state: _Reduced) -> dict:
+        return {"docs": []}
+
+    def tail(state: _Reduced) -> dict:
+        return {}
+
+    g = StateGraph(_Reduced)
+    g.add_node("a", seed)
+    g.add_node("b", empty)
+    g.add_node("c", tail)
+    g.add_edge(START, "a")
+    g.add_edge("a", "b")
+    g.add_edge("b", "c")
+    g.add_edge("c", END)
+    return g.compile()
+
+
+@pytest.mark.integration
+def test_state_after_honours_operator_add_reducer():
+    """state_after for a reduced field must match the graph, not last-write-wins."""
+    recorder = ArgusRecorder()
+    result = recorder.attach(_reduced_app()).invoke({})
+    assert result.get("docs") == ["seed"]
+
+    loaded = load_run(recorder.session.run_id)
+    rows = {r.node: r for r in build_ledger(loaded.steps, loaded.initial_state)}
+
+    assert rows["b"].update == {"docs": []}
+    assert rows["b"].state_after["docs"] == ["seed"]
+
+    live = build_ledger(recorder.session._events, recorder.session._initial_state)
+    reloaded = build_ledger(loaded.steps, loaded.initial_state)
+    assert [r.state_after for r in live] == [r.state_after for r in reloaded]


### PR DESCRIPTION
## Summary

`build_ledger` used a plain dict overlay for `state_after` (last write wins). For fields declared as `Annotated[list, operator.add]`, a node returning `{"docs": []}` therefore overwrote the accumulated list even though LangGraph kept it.

This rebuilds `state_after` from the next recorded step's `input_state` when one exists. That value is the framework's post-reducer merge, so reduced fields stay correct without persisting reducer callables. Live and reloaded notebooks stay identical. The last step still uses the overlay (no successor).

Fixes #80.

## Motivation

Issue #80: the notebook is the source of truth for re-score, but it lied about reduced fields. Grading is unaffected today, but tightening `_lacks` to treat `[]` as missing would immediately misfire.

## Implementation

Chosen the second candidate from the issue: rebuild `state_after` from each successor's recorded `input_state` rather than persist reducer identity. That keeps the run file unchanged and satisfies `test_ledger_from_live_steps_matches_the_reloaded_one`.

Limitation: fan-out without a recorded next event still falls back to last-write-wins for that row. Linear graphs and sequential recordings are covered.

## Testing

```
PYTHONPATH=src pytest tests/test_ledger.py tests/test_recorder.py tests/test_contextual.py tests/test_judge_last.py -v
```

- `tests/test_ledger.py`: 3 passed (including new `test_state_after_honours_operator_add_reducer`)
- `tests/test_contextual.py`: 4 passed
- `tests/test_judge_last.py`: 5 passed
- `tests/test_recorder.py`: 9 passed, 1 failed (`test_replay_refuses_a_trace_run_loudly`) with `ModuleNotFoundError: typer` — environment gap, unrelated to this change
